### PR TITLE
Add COT listener and affiliation change feature

### DIFF
--- a/app/src/main/java/com/engindearing/omnicot/AffiliationData.java
+++ b/app/src/main/java/com/engindearing/omnicot/AffiliationData.java
@@ -1,0 +1,134 @@
+package com.engindearing.omnicot;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Data model for storing CoT affiliation information
+ */
+public class AffiliationData {
+
+    public enum Affiliation {
+        UNKNOWN("unknown"),
+        ASSUMED_FRIENDLY("assumedFriendly"),
+        ASSUMED_HOSTILE("assumedHostile"),
+        PENDING("pending");
+
+        private final String value;
+
+        Affiliation(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static Affiliation fromString(String value) {
+            for (Affiliation affiliation : values()) {
+                if (affiliation.value.equalsIgnoreCase(value)) {
+                    return affiliation;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
+
+    private String uid;
+    private Affiliation affiliation;
+    private String markedBy;
+    private long timestamp;
+    private String serverConnection;
+    private String notes;
+
+    public AffiliationData(String uid, Affiliation affiliation, String markedBy, String serverConnection) {
+        this.uid = uid;
+        this.affiliation = affiliation;
+        this.markedBy = markedBy;
+        this.timestamp = System.currentTimeMillis();
+        this.serverConnection = serverConnection;
+        this.notes = "";
+    }
+
+    // Getters and Setters
+    public String getUid() {
+        return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    public Affiliation getAffiliation() {
+        return affiliation;
+    }
+
+    public void setAffiliation(Affiliation affiliation) {
+        this.affiliation = affiliation;
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    public String getMarkedBy() {
+        return markedBy;
+    }
+
+    public void setMarkedBy(String markedBy) {
+        this.markedBy = markedBy;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getServerConnection() {
+        return serverConnection;
+    }
+
+    public void setServerConnection(String serverConnection) {
+        this.serverConnection = serverConnection;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    // JSON Serialization
+    public JSONObject toJson() throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("uid", uid);
+        json.put("affiliation", affiliation.getValue());
+        json.put("markedBy", markedBy);
+        json.put("timestamp", timestamp);
+        json.put("serverConnection", serverConnection);
+        json.put("notes", notes);
+        return json;
+    }
+
+    public static AffiliationData fromJson(JSONObject json) throws JSONException {
+        String uid = json.getString("uid");
+        Affiliation affiliation = Affiliation.fromString(json.getString("affiliation"));
+        String markedBy = json.optString("markedBy", "");
+        String serverConnection = json.optString("serverConnection", "");
+
+        AffiliationData data = new AffiliationData(uid, affiliation, markedBy, serverConnection);
+        data.timestamp = json.optLong("timestamp", System.currentTimeMillis());
+        data.notes = json.optString("notes", "");
+
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        return "AffiliationData{" +
+                "uid='" + uid + '\'' +
+                ", affiliation=" + affiliation +
+                ", markedBy='" + markedBy + '\'' +
+                ", timestamp=" + timestamp +
+                ", serverConnection='" + serverConnection + '\'' +
+                '}';
+    }
+}

--- a/app/src/main/java/com/engindearing/omnicot/AffiliationManager.java
+++ b/app/src/main/java/com/engindearing/omnicot/AffiliationManager.java
@@ -1,0 +1,163 @@
+package com.engindearing.omnicot;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Manager for storing and retrieving CoT affiliation data
+ * Uses SharedPreferences for persistent storage
+ */
+public class AffiliationManager {
+    private static final String TAG = "AffiliationManager";
+    private static final String PREFS_NAME = "omnicot_affiliations";
+    private static final String KEY_PREFIX = "affiliation_";
+
+    private static AffiliationManager instance;
+    private final SharedPreferences prefs;
+    private final Context context;
+
+    private AffiliationManager(Context context) {
+        this.context = context.getApplicationContext();
+        this.prefs = this.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    public static synchronized AffiliationManager getInstance(Context context) {
+        if (instance == null) {
+            instance = new AffiliationManager(context);
+        }
+        return instance;
+    }
+
+    /**
+     * Store affiliation data for a CoT UID
+     */
+    public void setAffiliation(AffiliationData data) {
+        try {
+            String key = KEY_PREFIX + data.getUid();
+            String jsonString = data.toJson().toString();
+            prefs.edit().putString(key, jsonString).apply();
+            Log.d(TAG, "Stored affiliation for UID: " + data.getUid() + " -> " + data.getAffiliation());
+        } catch (JSONException e) {
+            Log.e(TAG, "Error storing affiliation data", e);
+        }
+    }
+
+    /**
+     * Retrieve affiliation data for a CoT UID
+     * @return AffiliationData or null if not found
+     */
+    public AffiliationData getAffiliation(String uid) {
+        String key = KEY_PREFIX + uid;
+        String jsonString = prefs.getString(key, null);
+
+        if (jsonString != null) {
+            try {
+                JSONObject json = new JSONObject(jsonString);
+                return AffiliationData.fromJson(json);
+            } catch (JSONException e) {
+                Log.e(TAG, "Error parsing affiliation data for UID: " + uid, e);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if affiliation exists for a UID
+     */
+    public boolean hasAffiliation(String uid) {
+        String key = KEY_PREFIX + uid;
+        return prefs.contains(key);
+    }
+
+    /**
+     * Remove affiliation data for a CoT UID
+     */
+    public void removeAffiliation(String uid) {
+        String key = KEY_PREFIX + uid;
+        prefs.edit().remove(key).apply();
+        Log.d(TAG, "Removed affiliation for UID: " + uid);
+    }
+
+    /**
+     * Get all stored affiliations
+     */
+    public List<AffiliationData> getAllAffiliations() {
+        List<AffiliationData> affiliations = new ArrayList<>();
+        Map<String, ?> allPrefs = prefs.getAll();
+
+        for (Map.Entry<String, ?> entry : allPrefs.entrySet()) {
+            if (entry.getKey().startsWith(KEY_PREFIX)) {
+                try {
+                    String jsonString = (String) entry.getValue();
+                    if (jsonString != null) {
+                        JSONObject json = new JSONObject(jsonString);
+                        affiliations.add(AffiliationData.fromJson(json));
+                    }
+                } catch (JSONException e) {
+                    Log.e(TAG, "Error parsing affiliation data", e);
+                }
+            }
+        }
+
+        return affiliations;
+    }
+
+    /**
+     * Clear all affiliation data
+     */
+    public void clearAll() {
+        SharedPreferences.Editor editor = prefs.edit();
+        Map<String, ?> allPrefs = prefs.getAll();
+
+        for (String key : allPrefs.keySet()) {
+            if (key.startsWith(KEY_PREFIX)) {
+                editor.remove(key);
+            }
+        }
+
+        editor.apply();
+        Log.d(TAG, "Cleared all affiliation data");
+    }
+
+    /**
+     * Get count of stored affiliations
+     */
+    public int getAffiliationCount() {
+        int count = 0;
+        Map<String, ?> allPrefs = prefs.getAll();
+
+        for (String key : allPrefs.keySet()) {
+            if (key.startsWith(KEY_PREFIX)) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * Update affiliation for existing data
+     */
+    public void updateAffiliation(String uid, AffiliationData.Affiliation newAffiliation, String markedBy) {
+        AffiliationData existingData = getAffiliation(uid);
+
+        if (existingData != null) {
+            existingData.setAffiliation(newAffiliation);
+            existingData.setMarkedBy(markedBy);
+            setAffiliation(existingData);
+        } else {
+            // Create new affiliation data
+            AffiliationData newData = new AffiliationData(uid, newAffiliation, markedBy, "");
+            setAffiliation(newData);
+        }
+    }
+}

--- a/app/src/main/java/com/engindearing/omnicot/CotAffiliationListener.java
+++ b/app/src/main/java/com/engindearing/omnicot/CotAffiliationListener.java
@@ -1,0 +1,190 @@
+package com.engindearing.omnicot;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.atakmap.android.maps.MapView;
+import com.atakmap.comms.CommsLogger;
+import com.atakmap.coremap.cot.event.CotDetail;
+import com.atakmap.coremap.cot.event.CotEvent;
+
+/**
+ * CoT listener that monitors incoming CoT messages for affiliation information
+ * Implements CommsLogger to hook into ATAK's CoT processing pipeline
+ */
+public class CotAffiliationListener implements CommsLogger {
+    private static final String TAG = "CotAffiliationListener";
+    private static final String AFFILIATION_DETAIL_TAG = "__omnicot_affiliation";
+
+    private final Context context;
+    private final AffiliationManager affiliationManager;
+    private final String localCallsign;
+
+    public CotAffiliationListener(Context context) {
+        this.context = context;
+        this.affiliationManager = AffiliationManager.getInstance(context);
+
+        // Get local callsign from ATAK
+        MapView mapView = MapView.getMapView();
+        if (mapView != null) {
+            this.localCallsign = mapView.getDeviceCallsign();
+        } else {
+            this.localCallsign = "Unknown";
+        }
+
+        Log.d(TAG, "CotAffiliationListener initialized with callsign: " + localCallsign);
+    }
+
+    @Override
+    public void logReceive(CotEvent event, String rxid, String server) {
+        if (event == null) {
+            return;
+        }
+
+        try {
+            String uid = event.getUID();
+            if (uid == null || uid.isEmpty()) {
+                return;
+            }
+
+            // Check if the CoT event contains affiliation detail
+            CotDetail detail = event.getDetail();
+            if (detail != null) {
+                CotDetail affiliationDetail = detail.getFirstChildByName(0, AFFILIATION_DETAIL_TAG);
+
+                if (affiliationDetail != null) {
+                    // Extract affiliation information from the detail
+                    String affiliationValue = affiliationDetail.getAttribute("affiliation");
+                    String markedBy = affiliationDetail.getAttribute("markedBy");
+                    String notes = affiliationDetail.getAttribute("notes");
+
+                    if (affiliationValue != null) {
+                        AffiliationData.Affiliation affiliation =
+                            AffiliationData.Affiliation.fromString(affiliationValue);
+
+                        // Check if we already have this affiliation stored
+                        AffiliationData existingData = affiliationManager.getAffiliation(uid);
+
+                        if (existingData != null) {
+                            // Update existing affiliation if it's different
+                            if (existingData.getAffiliation() != affiliation ||
+                                !existingData.getMarkedBy().equals(markedBy)) {
+
+                                existingData.setAffiliation(affiliation);
+                                existingData.setMarkedBy(markedBy);
+                                existingData.setServerConnection(server);
+                                if (notes != null && !notes.isEmpty()) {
+                                    existingData.setNotes(notes);
+                                }
+
+                                affiliationManager.setAffiliation(existingData);
+
+                                Log.d(TAG, "Updated affiliation for " + uid + ": " + affiliation +
+                                      " (marked by " + markedBy + ")");
+                            }
+                        } else {
+                            // Create new affiliation entry
+                            AffiliationData newData = new AffiliationData(
+                                uid, affiliation, markedBy, server
+                            );
+                            if (notes != null && !notes.isEmpty()) {
+                                newData.setNotes(notes);
+                            }
+
+                            affiliationManager.setAffiliation(newData);
+
+                            Log.d(TAG, "New affiliation received for " + uid + ": " + affiliation +
+                                  " (marked by " + markedBy + ")");
+                        }
+                    }
+                }
+            }
+
+            // Also check if we have existing affiliation data for this UID
+            // This helps maintain affiliation even when the CoT doesn't include the detail
+            if (!affiliationManager.hasAffiliation(uid)) {
+                // Create default UNKNOWN affiliation for new CoT items
+                AffiliationData defaultData = new AffiliationData(
+                    uid,
+                    AffiliationData.Affiliation.UNKNOWN,
+                    "System",
+                    server
+                );
+                affiliationManager.setAffiliation(defaultData);
+
+                Log.d(TAG, "Created default UNKNOWN affiliation for new CoT: " + uid);
+            } else {
+                // Update server connection for existing affiliation
+                AffiliationData existingData = affiliationManager.getAffiliation(uid);
+                if (existingData != null && !server.equals(existingData.getServerConnection())) {
+                    existingData.setServerConnection(server);
+                    affiliationManager.setAffiliation(existingData);
+                }
+            }
+
+        } catch (Exception e) {
+            Log.e(TAG, "Error processing received CoT event", e);
+        }
+    }
+
+    @Override
+    public void logSend(CotEvent event, String destination) {
+        // We can track outgoing affiliation updates here if needed
+        if (event == null) {
+            return;
+        }
+
+        try {
+            CotDetail detail = event.getDetail();
+            if (detail != null) {
+                CotDetail affiliationDetail = detail.getFirstChildByName(0, AFFILIATION_DETAIL_TAG);
+                if (affiliationDetail != null) {
+                    String uid = event.getUID();
+                    String affiliationValue = affiliationDetail.getAttribute("affiliation");
+
+                    Log.d(TAG, "Sending affiliation update for " + uid + ": " +
+                          affiliationValue + " to " + destination);
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error processing sent CoT event", e);
+        }
+    }
+
+    @Override
+    public void logSend(CotEvent event, String[] toUIDs) {
+        // Track sends to multiple UIDs
+        if (event == null || toUIDs == null || toUIDs.length == 0) {
+            return;
+        }
+
+        try {
+            CotDetail detail = event.getDetail();
+            if (detail != null) {
+                CotDetail affiliationDetail = detail.getFirstChildByName(0, AFFILIATION_DETAIL_TAG);
+                if (affiliationDetail != null) {
+                    String uid = event.getUID();
+                    String affiliationValue = affiliationDetail.getAttribute("affiliation");
+
+                    Log.d(TAG, "Sending affiliation update for " + uid + ": " +
+                          affiliationValue + " to " + toUIDs.length + " recipients");
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error processing sent CoT event to UIDs", e);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        Log.d(TAG, "CotAffiliationListener disposed");
+        // Cleanup if needed
+    }
+
+    /**
+     * Get the detail tag name used for affiliation information
+     */
+    public static String getAffiliationDetailTag() {
+        return AFFILIATION_DETAIL_TAG;
+    }
+}

--- a/app/src/main/java/com/engindearing/omnicot/OmniCOTMapComponent.java
+++ b/app/src/main/java/com/engindearing/omnicot/OmniCOTMapComponent.java
@@ -9,6 +9,7 @@ import com.atakmap.android.dropdown.DropDownMapComponent;
 import com.atakmap.android.ipc.AtakBroadcast;
 import com.atakmap.android.ipc.AtakBroadcast.DocumentedIntentFilter;
 import com.atakmap.android.maps.MapView;
+import com.atakmap.comms.CommsMapComponent;
 import com.atakmap.coremap.log.Log;
 
 public class OmniCOTMapComponent extends DropDownMapComponent {
@@ -17,6 +18,7 @@ public class OmniCOTMapComponent extends DropDownMapComponent {
 
     private Context pluginContext;
     private OmniCOTDropDownReceiver dropDownReceiver;
+    private CotAffiliationListener affiliationListener;
 
     public OmniCOTMapComponent() {
         Log.d(TAG, "OmniCOTMapComponent constructor called");
@@ -41,6 +43,11 @@ public class OmniCOTMapComponent extends DropDownMapComponent {
         ddFilter.addAction(OmniCOTDropDownReceiver.SHOW_PLUGIN, "Show the OmniCOT Dashboard");
         registerDropDownReceiver(dropDownReceiver, ddFilter);
         Log.d(TAG, "Registered OmniCOT DropDownReceiver successfully");
+
+        // Register CoT affiliation listener
+        affiliationListener = new CotAffiliationListener(pluginContext);
+        CommsMapComponent.getInstance().registerCommsLogger(affiliationListener);
+        Log.d(TAG, "Registered CotAffiliationListener for monitoring CoT messages");
     }
 
     @Override
@@ -49,6 +56,13 @@ public class OmniCOTMapComponent extends DropDownMapComponent {
 
         if (dropDownReceiver != null) {
             dropDownReceiver.dispose();
+        }
+
+        // Unregister CoT affiliation listener
+        if (affiliationListener != null) {
+            CommsMapComponent.getInstance().unregisterCommsLogger(affiliationListener);
+            affiliationListener.dispose();
+            Log.d(TAG, "Unregistered CotAffiliationListener");
         }
 
         Log.d(TAG, "OmniCOT MapComponent destroyed");

--- a/app/src/main/res/layout/main_layout.xml
+++ b/app/src/main/res/layout/main_layout.xml
@@ -76,6 +76,29 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Team Affiliation Tracking:"
+                android:paddingTop="12dp"
+                android:textStyle="bold" />
+
+            <Spinner
+                android:id="@+id/spinnerCustomAffiliation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/txtAffiliationInfo"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="No affiliation data"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                android:textSize="12sp"
+                android:textColor="#666666"
+                android:visibility="gone" />
+
             <Button
                 android:id="@+id/btnUpdateAffiliation"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,12 @@
         <item>Unknown Only</item>
     </string-array>
 
+    <!-- Custom team affiliation tracking options -->
+    <string-array name="custom_affiliation_types">
+        <item>Unknown</item>
+        <item>Assumed Friendly</item>
+        <item>Assumed Hostile</item>
+        <item>Pending</item>
+    </string-array>
+
 </resources>


### PR DESCRIPTION
Implements a comprehensive CoT affiliation tracking system that allows the team to monitor and share affiliation status of CoT objects.

Features:
- CotAffiliationListener: Listens to all incoming/outgoing CoT messages using CommsLogger
- AffiliationData: Data model with 4 affiliation types (Unknown, Assumed Friendly, Assumed Hostile, Pending)
- AffiliationManager: Persistent storage using SharedPreferences to track affiliations by UID
- Team synchronization: Affiliation updates are federated to all team members via CoT details
- Persistent tracking: Affiliations persist across location changes and server reconnections
- UI enhancements: Shows who marked the affiliation and when
- Dashboard integration: Tracks affiliation changes in activity log

The system automatically:
- Creates default UNKNOWN affiliation for new CoT objects
- Syncs affiliation data across the team when updates occur
- Displays marking user and notes for team awareness
- Maintains affiliation data even when CoT moves to new location